### PR TITLE
TaskManager.execute now respects the task order it was queued up in

### DIFF
--- a/mplite/__init__.py
+++ b/mplite/__init__.py
@@ -4,9 +4,10 @@ import traceback
 import time
 from tqdm import tqdm as _tqdm
 import queue
+from uuid import uuid4 as uuid
 
 
-major, minor, patch = 1, 2, 2
+major, minor, patch = 1, 2, 3
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)
 
@@ -22,6 +23,7 @@ class Task(object):
         if not isinstance(kwargs, dict):
             raise TypeError(f"{kwargs} is not a dict")
         self.kwargs = kwargs
+        self._key = str(uuid())
 
     def __str__(self) -> str:
         return f"Task(f={self.f.__name__}, *{self.args}, **{self.kwargs})"
@@ -62,7 +64,7 @@ class Worker(multiprocessing.Process):
 
             elif isinstance(task, Task):
                 result = task.execute()
-                self.rq.put(result)
+                self.rq.put((task._key, result))
             else:
                 time.sleep(0.01)
 
@@ -115,10 +117,14 @@ class TaskManager(object):
             Tracks the execution progress using tqdm instance,
             if None is provided, progress bar will be created using tqdm callable provided by tqdm parameter.
         """
-        self._open_tasks += len(tasks)
-        for t in tasks:
+        task_count = len(tasks)
+        self._open_tasks += task_count
+        task_indices = {}
+
+        for i, t in enumerate(tasks):
             self.tq.put(t)
-        results = []
+            task_indices[t._key] = i
+        results = [None] * task_count
 
         if pbar is None:
             """ if pbar object was not passed, create a new tqdm compatibe object """
@@ -126,9 +132,9 @@ class TaskManager(object):
 
         while self._open_tasks != 0:
             try:
-                task = self.rq.get_nowait()
+                task_key, res = self.rq.get_nowait()
                 self._open_tasks -= 1
-                results.append(task)
+                results[task_indices[task_key]] = res
                 pbar.update(1)
             except queue.Empty:
                 dead_processes = list(filter(lambda p: not p.is_alive() and p.exitcode != 0, self.pool))
@@ -153,7 +159,7 @@ class TaskManager(object):
     def take(self):
         """ permits asynchronous retrieval of results """
         try:
-            result = self.rq.get_nowait()
+            _, result = self.rq.get_nowait()
             self._open_tasks -= 1
         except queue.Empty:
             result = None

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -3,7 +3,7 @@ import platform
 import signal
 from mplite import TaskManager,Task
 import time
-
+import random
 
 def test_alpha():
     args = list(range(10)) * 5
@@ -144,3 +144,22 @@ def test_abrupt_exit():
 
     except ChildProcessError as ex:
         assert "42" in str(ex), "Must be out of memory exception"
+
+
+def task(index):
+    time.sleep(random.random() * 2)
+
+    return index
+
+
+def test_task_order():
+
+    tasks = [Task(task, (i, )) for i in range(10)]
+
+    with TaskManager(10) as tm:
+        res = [k for k, *_ in tm.execute(tasks)]
+
+    assert res == list(range(10))
+
+if __name__ == "__main__":
+    test_task_order()


### PR DESCRIPTION
As per title `TaskManager.execute` results will now be retrieved in the same order that the tasks were queued up in, instead of being returned in random order based on which task completes first.

Related to #7 , assuming `.execute` being out of order was in fact not expected behaviour.