### PR TITLE
Non-blocking chained execute API

### DIFF
--- a/mplite/__init__.py
+++ b/mplite/__init__.py
@@ -6,9 +6,10 @@ import time
 from tqdm import tqdm as _tqdm
 import queue
 from itertools import count
+from typing import Callable, Any, Concatenate, Union, Tuple, ParamSpec
 from multiprocessing.context import BaseContext
 
-major, minor, patch = 1, 2, 6
+major, minor, patch = 1, 2, 7
 __version_info__ = (major, minor, patch)
 __version__ = '.'.join(str(i) for i in __version_info__)
 default_context = "spawn"
@@ -30,7 +31,7 @@ class Task(object):
         self.id = next(Task.task_id_counter)
 
     def __str__(self) -> str:
-        return f"Task(f={self.f.__name__}, *{self.args}, **{self.kwargs})"
+        return repr(self)
 
     def __repr__(self) -> str:
         return f"Task(f={self.f.__name__}, *{self.args}, **{self.kwargs})"
@@ -45,6 +46,53 @@ class Task(object):
             error = f.read()
             f.close()
             return error
+
+class TaskChain(object):
+    def __init__(self, task: Task, next_task: Callable[[Task, Any], Union[Task, "TaskChain"]] = None) -> None:
+        """
+            allows for promise-like chain execution of tasks, where one task depends on the output of another
+            only supported by TaskManager.execute API, submit/take would have to be implemented manually
+
+            reasoning: sometimes you want multiple steps of tasks executed,
+            however, when using .execute API the system would wait for results in a blocking manner
+            this API allows you to create a new task that gets queued automatically once the parent task is ready,
+            this allows for each of the steps to be executed in a non-blocking manner
+        """
+        self.id = next(Task.task_id_counter)
+        self.task = task
+        self.next = next_task
+
+        self.task.id = self.id
+
+    def resolve(self, result):
+        """ called by task manager, when TaskChain is executed, if not last task, create a new task and shove it into task queue """
+        if self.next is not None:
+            task = self.next(self.task, result)
+            task.id = self.id
+
+            if isinstance(task, TaskChain):
+                task.task.id = self.id
+
+            return task
+        raise StopIteration()
+    
+    def __str__(self) -> str:
+        return repr(self)
+
+    def __repr__(self) -> str:
+        return f"TaskChain(f={self.task.f.__name__}, *{self.task.args}, **{self.task.kwargs}, is_last={self.next is None})"
+    
+    def execute(self):
+        """ execute task chain synchronously """
+        t = self
+
+        while True:
+            if isinstance(t, TaskChain):
+                t = t.resolve(t.task.execute())
+            elif isinstance(t, Task):
+                return t.execute()
+            else:
+                raise Exception("invalid type")
 
 
 class Worker(object):
@@ -133,7 +181,7 @@ class TaskManager(object):
         while not all(p.is_alive() for p in self.pool):
             time.sleep(0.01)
 
-    def execute(self, tasks: "list[Task]", tqdm=_tqdm, pbar: _tqdm=None):
+    def execute(self, tasks: "list[Union[Task, TaskChain]]", tqdm=_tqdm, pbar: _tqdm=None):
         """
         Execute tasks using mplite
 
@@ -160,11 +208,11 @@ class TaskManager(object):
         """
         task_count = len(tasks)
         self._open_tasks += task_count
-        task_indices = {}
+        task_indices: dict[int, Tuple[int, Union[Task, TaskChain]]] = {}
 
         for i, t in enumerate(tasks):
-            self.tq.put(t)
-            task_indices[t.id] = i
+            self.tq.put(t if isinstance(t, Task) else t.task)
+            task_indices[t.id] = (i, t)
         results = [None] * task_count
 
         if pbar is None:
@@ -174,9 +222,15 @@ class TaskManager(object):
         while self._open_tasks != 0:
             try:
                 task_key, res = self.rq.get_nowait()
-                self._open_tasks -= 1
-                results[task_indices[task_key]] = res
-                pbar.update(1)
+                idx, t = task_indices[task_key]
+                if isinstance(t, Task) or t.next is None:
+                    self._open_tasks -= 1
+                    results[idx] = res
+                    pbar.update(1)
+                else:
+                    t = t.resolve(res)
+                    task_indices[task_key] = (idx, t)
+                    self.tq.put(t if isinstance(t, Task) else t.task)
             except queue.Empty:
                 dead_processes = list(filter(lambda p: not p.is_alive() and p.exitcode != 0, self.pool))
                 if len(dead_processes) > 0:

--- a/mplite/__init__.py
+++ b/mplite/__init__.py
@@ -6,7 +6,7 @@ import time
 from tqdm import tqdm as _tqdm
 import queue
 from itertools import count
-from typing import Callable, Any, Concatenate, Union, Tuple, ParamSpec
+from typing import Callable, Any, Union, Tuple
 from multiprocessing.context import BaseContext
 
 major, minor, patch = 1, 2, 7


### PR DESCRIPTION
Execute API now supports non-blocking task execution. Currently if you want to execute multiple steps of tasks using execute API you would have to wait for all tasks in the call to execute, this allows promise-like behaviour where the other step can start immediately after the other has completed without having to wait for blockers. The .execute will now finish when all chains of all tasks complete, the result is the result of the last task in chain.